### PR TITLE
Add Custom CUDA Version Support

### DIFF
--- a/chslauncher.sh
+++ b/chslauncher.sh
@@ -95,7 +95,15 @@ if [ -d $env_dir ]; then
         esac
     done
 else
-    echo "No existing $folder_name found. Start creating a new one"
+    # echo "No existing $folder_name found. Start creating a new one"
+    read -p "No existing $folder_name found. Do you want to create a new one? [y]/n: " answer
+    # Convert the input to lowercase
+    answer=$(echo "$answer" | tr '[:upper:]' '[:lower:]')
+
+    # quit if answer is not y or yes
+    if [[ "$answer" != "y" && "$answer" != "yes" ]]; then
+       exit 1
+    fi
 fi
 
 if [ $install_new_env -eq 1 ]; then


### PR DESCRIPTION
### Changes Made:
-  Added custom CUDA version option in the menu
-  Implemented Docker Hub fallback with minor version retry (0-5)
-  Fixed downloader issues for custom CUDA images (no wget/curl)
-  Added proper bind mount handling for custom builds
-  Fixed conda Terms of Service acceptance
-  Added working directory protection during gunzip

### Features:
- **Custom CUDA Support**: Users can now build any CUDA version from Docker Hub
- **Automatic Fallback**: Tries multiple minor versions (e.g., 12.4.0, 12.4.1, etc.)
- **Robust Installation**: Downloads Miniconda on host, copies to container
- **Clean Error Handling**: Proper error messages and graceful failures

### Testing:
-  Tested with CUDA 12.4, 12.9 custom build
-  Verified prebuilt images still work unchanged
-  Confirmed conda installation and environment setup